### PR TITLE
Fixed issues with travis.yml indentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,27 @@
 language: android
-
 android:
   components:
-  - tools
-  - build-tools-25.0.2
-  - android-25
-  - sys-img-armeabi-v7a-android-25
+    - tools
+    - build-tools-25.0.2
+    - android-25
+    - sys-img-armeabi-v7a-android-25
   
- licenses:
-  - android-sdk-preview-license-.+
-  - android-sdk-license-.+
+  licenses:
+    - android-sdk-preview-license-.+
+    - android-sdk-license-.+
 
 jdk:
-- oraclejdk8
+  - oraclejdk8
 
 addons:
   sonarqube: true
 
 before_install:
-- chmod +x gradlew
+  - chmod +x gradlew
 
 script:
-- ./gradlew build connectedCheck
-- sonar-scanner -Dsonar.login=$SONAR_TOKEN
+  - ./gradlew build connectedCheck
+  - sonar-scanner -Dsonar.login=$SONAR_TOKEN
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ android:
     - build-tools-25.0.2
     - android-25
     - sys-img-armeabi-v7a-android-25
-  
-  licenses:
-    - android-sdk-preview-license-.+
-    - android-sdk-license-.+
 
 jdk:
   - oraclejdk8

--- a/src/test/java/nitezh/ministock/domain/StockQuoteRepositoryTests.java
+++ b/src/test/java/nitezh/ministock/domain/StockQuoteRepositoryTests.java
@@ -79,12 +79,12 @@ public class StockQuoteRepositoryTests {
 
         StockQuote aaplQuote = quotes.get("AAPL");
         assertEquals("AAPL", aaplQuote.getSymbol());
-        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "Nasdaq Global Select").contains(aaplQuote.getExchange()));
+        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "NasdaqGS", "NASDAQ").contains(aaplQuote.getExchange()));
         assertEquals("Apple Inc.", aaplQuote.getName());
 
         StockQuote googQuote = quotes.get("GOOG");
         assertEquals("GOOG", googQuote.getSymbol());
-        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "Nasdaq Global Select").contains(googQuote.getExchange()));
+        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "NasdaqGS", "NASDAQ").contains(googQuote.getExchange()));
         assertEquals("Alphabet Inc.", googQuote.getName());
 
         StockQuote djiQuote = quotes.get("^DJI");
@@ -112,12 +112,12 @@ public class StockQuoteRepositoryTests {
 
         StockQuote aaplQuote = quotes.get("AAPL");
         assertEquals("AAPL", aaplQuote.getSymbol());
-        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "Nasdaq Global Select").contains(aaplQuote.getExchange()));
+        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "NasdaqGS").contains(aaplQuote.getExchange()));
         assertEquals("Apple Inc.", aaplQuote.getName());
 
         StockQuote googQuote = quotes.get("GOOG");
         assertEquals("GOOG", googQuote.getSymbol());
-        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "Nasdaq Global Select").contains(googQuote.getExchange()));
+        Assert.assertTrue(Arrays.asList("NasdaqNM", "NMS", "NasdaqGS").contains(googQuote.getExchange()));
         assertEquals("Alphabet Inc.", googQuote.getName());
 
         StockQuote djiQuote = quotes.get("^DJI");


### PR DESCRIPTION
This pull request relates to issue #6. There were some indentation errors in the .travis.yml file that were preventing the build to execute so it was just reverting to travis' default configuration (i.e.: it was setting the language as ruby). That's why all of our builds wouldn't even run and we'd get this error:

    rake aborted!
    No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)

The build still fails but now its just not because of errors of Travis but because of the actual failing unit tests in the StockQuoteRepositoryTests class. 