### PR TITLE
second "resizable" widget view to show horizontal resize

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -212,9 +212,9 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_2x4" />
         </receiver>
-        <receiver android:name=".activities.widget.WidgetProviderResizable"
-            android:label="Resizable"
-            >
+        <receiver
+            android:name=".activities.widget.WidgetProviderResizable"
+            android:label="Resizable">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -223,7 +223,16 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/widget_resizable" />
         </receiver>
+        <receiver android:name=".activities.widget.WidgetProviderResizable2"
+            android:label="Resizable2">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
 
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_resizable2_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/src/main/java/nitezh/ministock/activities/configure/ConfigureActivityResizable2.java
+++ b/src/main/java/nitezh/ministock/activities/configure/ConfigureActivityResizable2.java
@@ -1,0 +1,16 @@
+package nitezh.ministock.activities.configure;
+
+
+import android.os.Bundle;
+
+/**
+ * Implementation of App Widget functionality.
+ */
+public class ConfigureActivityResizable2 extends ConfigureActivityBase {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        mWidgetSize = 3;
+        super.onCreate(savedInstanceState);
+    }}
+

--- a/src/main/java/nitezh/ministock/activities/widget/WidgetProviderResizable2.java
+++ b/src/main/java/nitezh/ministock/activities/widget/WidgetProviderResizable2.java
@@ -1,0 +1,11 @@
+package nitezh.ministock.activities.widget;
+
+
+
+/**
+ * Created by Andy on 2018-02-07.
+ */
+
+public class WidgetProviderResizable2 extends WidgetProviderBase {
+
+}

--- a/src/main/res/layout/widget_resizable2.xml
+++ b/src/main/res/layout/widget_resizable2.xml
@@ -1,0 +1,26 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/widget_margin">
+
+    <ImageView
+        android:id="@+id/widget_bg"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:adjustViewBounds="false"
+        android:contentDescription="@string/_2x4_widget_background"
+        android:orientation="horizontal"
+        android:scaleType="fitXY"
+        android:src="@drawable/ministock_bg_transparent68" />
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:orientation="horizontal"
+        android:paddingBottom="3dp">
+
+        <include layout="@layout/widget_columns4" />
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/src/main/res/xml/widget_resizable2_info.xml
+++ b/src/main/res/xml/widget_resizable2_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="nitezh.ministock.activities.configure.ConfigureActivityResizable"
+    android:initialLayout="@layout/widget_resizable"
+    android:minHeight="72dp"
+    android:minWidth="146dp"
+    android:resizeMode="vertical|horizontal"
+    android:updatePeriodMillis="7200000"
+    >
+
+</appwidget-provider>


### PR DESCRIPTION
# Description
Added a new widget view "resizable2" that shows that horizontal resize is possible

# Fixes the Issue #none  
The user may resize both vertically and horizontally the widget view "resizable".

# Testing the Feature
The steps to be followed will be identical to resizing the widget view "resizable". 

- Add the widget view "resizable2" to the screen space.
- Hold onto the widget until the device prompt to make an action with the widget
- Release the widget, a white rectangle should appear around the widget
- Hold onto either circles on the top or bottom of the white rectangle and slide to adjust the widget to the desired size.

![image](https://user-images.githubusercontent.com/25252836/36132206-d3f686f8-1043-11e8-858b-0ce1613423dd.png)


The widget displayed should keep the size that was stretched.



